### PR TITLE
Refactor/task attachment

### DIFF
--- a/__tests__/unit/api/attachments-route.test.ts
+++ b/__tests__/unit/api/attachments-route.test.ts
@@ -53,18 +53,11 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
       public_url: 'https://example.com/document.pdf',
     };
 
-    // Setup mock chains
-    // First call: Fetch the attachment metadata (.select().eq().eq().single())
-    mockSelectChain = {
-      eq: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({
-        data: mockAttachment,
-        error: null,
-      }),
-    };
-
-    // After fetching, set up for reference count check (.select().eq())
-    // We need to handle two separate calls to from('attachments').select()
+    // We need to handle 4 calls to supabase.from('attachments').select():
+    // 1. Fetch attachment metadata
+    // 2. Check references BEFORE deletion
+    // 3. (delete happens)
+    // 4. Check references AFTER deletion (should be 0)
     let callCount = 0;
     supabase.from = jest.fn(() => ({
       select: jest.fn(() => {
@@ -78,25 +71,30 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
               error: null,
             }),
           };
-        } else {
-          // Second call: check for references - only 1 reference
+        } else if (callCount === 2) {
+          // Second call: check references BEFORE deletion - 1 reference
           return {
             eq: jest.fn().mockResolvedValue({
-              data: [{ id: 'attachment-1' }],
+              data: [{ id: 'attachment-1', task_id: 1 }],
+              error: null,
+            }),
+          };
+        } else {
+          // Third+ call: check references AFTER deletion - 0 references
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [],
               error: null,
             }),
           };
         }
       }),
-      delete: jest.fn(() => mockDeleteChain),
+      delete: jest.fn(() => ({
+        eq: jest.fn().mockResolvedValue({
+          error: null,
+        }),
+      })),
     }));
-
-    // Mock: Delete from database
-    mockDeleteChain = {
-      eq: jest.fn().mockResolvedValue({
-        error: null,
-      }),
-    };
 
     // Mock: Delete from storage
     supabaseAdmin.storage.remove.mockResolvedValue({
@@ -152,14 +150,25 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
               error: null,
             }),
           };
-        } else {
-          // Second call: check for references - 3 references (recurring task)
+        } else if (callCount === 2) {
+          // Second call: check references BEFORE deletion - 3 references
           return {
             eq: jest.fn().mockResolvedValue({
               data: [
-                { id: 'attachment-1' },
-                { id: 'attachment-2' },
-                { id: 'attachment-3' },
+                { id: 'attachment-1', task_id: 1 },
+                { id: 'attachment-2', task_id: 11 },
+                { id: 'attachment-3', task_id: 12 },
+              ],
+              error: null,
+            }),
+          };
+        } else {
+          // Third+ call: check references AFTER deletion - 2 references remain
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { id: 'attachment-2', task_id: 11 },
+                { id: 'attachment-3', task_id: 12 },
               ],
               error: null,
             }),

--- a/__tests__/unit/api/attachments-route.test.ts
+++ b/__tests__/unit/api/attachments-route.test.ts
@@ -1,0 +1,297 @@
+/** @jest-environment node */
+/**
+ * Unit tests for Attachment API - Reference Counting for Deletion
+ * Tests the refactored DELETE endpoint that only removes files from storage
+ * when no other tasks reference the same storage_path
+ */
+
+import { DELETE } from '@/app/api/tasks/[id]/attachments/route';
+
+// Mock chain builder for Supabase
+let mockSelectChain: any;
+let mockDeleteChain: any;
+
+// Mock Supabase clients
+jest.mock('@/lib/supabaseClient', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => mockSelectChain),
+      delete: jest.fn(() => mockDeleteChain),
+    })),
+  },
+}));
+
+jest.mock('@/lib/supabaseAdmin', () => ({
+  supabaseAdmin: {
+    storage: {
+      from: jest.fn().mockReturnThis(),
+      remove: jest.fn(),
+    },
+  },
+}));
+
+// Import mocked modules
+const { supabase } = require('@/lib/supabaseClient');
+const { supabaseAdmin } = require('@/lib/supabaseAdmin');
+
+// Set environment variable for tests
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Should delete from storage when attachment has only 1 reference (non-recurring task)', async () => {
+    // Mock attachment data
+    const mockAttachment = {
+      id: 'attachment-1',
+      task_id: 1,
+      filename: 'document.pdf',
+      storage_path: 'task-1/document.pdf',
+      public_url: 'https://example.com/document.pdf',
+    };
+
+    // Setup mock chains
+    // First call: Fetch the attachment metadata (.select().eq().eq().single())
+    mockSelectChain = {
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: mockAttachment,
+        error: null,
+      }),
+    };
+
+    // After fetching, set up for reference count check (.select().eq())
+    // We need to handle two separate calls to from('attachments').select()
+    let callCount = 0;
+    supabase.from = jest.fn(() => ({
+      select: jest.fn(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: fetch attachment metadata
+          return {
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: mockAttachment,
+              error: null,
+            }),
+          };
+        } else {
+          // Second call: check for references - only 1 reference
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: 'attachment-1' }],
+              error: null,
+            }),
+          };
+        }
+      }),
+      delete: jest.fn(() => mockDeleteChain),
+    }));
+
+    // Mock: Delete from database
+    mockDeleteChain = {
+      eq: jest.fn().mockResolvedValue({
+        error: null,
+      }),
+    };
+
+    // Mock: Delete from storage
+    supabaseAdmin.storage.remove.mockResolvedValue({
+      error: null,
+    });
+
+    // Create mock request
+    const request = new Request(
+      'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
+      { method: 'DELETE' }
+    );
+
+    // Execute DELETE
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: '1' }),
+    });
+    const data = await response.json();
+
+    // Assertions
+    expect(response.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.deletedFromStorage).toBe(true);
+
+    // Verify storage deletion was called
+    expect(supabaseAdmin.storage.from).toHaveBeenCalledWith('attachments');
+    expect(supabaseAdmin.storage.remove).toHaveBeenCalledWith(['task-1/document.pdf']);
+
+    // Verify database deletion was called (check via from call which returns delete chain)
+    expect(supabase.from).toHaveBeenCalledWith('attachments');
+  });
+
+  test('Should NOT delete from storage when attachment has multiple references (recurring task)', async () => {
+    // Mock attachment data
+    const mockAttachment = {
+      id: 'attachment-1',
+      task_id: 1,
+      filename: 'recurring-doc.pdf',
+      storage_path: 'task-1/recurring-doc.pdf',
+      public_url: 'https://example.com/recurring-doc.pdf',
+    };
+
+    // Setup mock chains for multiple references
+    let callCount = 0;
+    supabase.from = jest.fn(() => ({
+      select: jest.fn(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: fetch attachment metadata
+          return {
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: mockAttachment,
+              error: null,
+            }),
+          };
+        } else {
+          // Second call: check for references - 3 references (recurring task)
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { id: 'attachment-1' },
+                { id: 'attachment-2' },
+                { id: 'attachment-3' },
+              ],
+              error: null,
+            }),
+          };
+        }
+      }),
+      delete: jest.fn(() => ({
+        eq: jest.fn().mockResolvedValue({
+          error: null,
+        }),
+      })),
+    }));
+
+    // Create mock request
+    const request = new Request(
+      'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
+      { method: 'DELETE' }
+    );
+
+    // Execute DELETE
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: '1' }),
+    });
+    const data = await response.json();
+
+    // Assertions
+    expect(response.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.deletedFromStorage).toBe(false);
+
+    // Verify storage deletion was NOT called
+    expect(supabaseAdmin.storage.remove).not.toHaveBeenCalled();
+
+    // Verify database deletion WAS called (only removes DB row)
+    expect(supabase.from).toHaveBeenCalledWith('attachments');
+  });
+
+  test('Should handle error when checking attachment references', async () => {
+    // Mock attachment data
+    const mockAttachment = {
+      id: 'attachment-1',
+      task_id: 1,
+      filename: 'document.pdf',
+      storage_path: 'task-1/document.pdf',
+    };
+
+    // Setup mock chains with error on second call
+    let callCount = 0;
+    supabase.from = jest.fn(() => ({
+      select: jest.fn(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: fetch attachment metadata
+          return {
+            eq: jest.fn().mockReturnThis(),
+            single: jest.fn().mockResolvedValue({
+              data: mockAttachment,
+              error: null,
+            }),
+          };
+        } else {
+          // Second call: error checking references
+          return {
+            eq: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'Database error' },
+            }),
+          };
+        }
+      }),
+    }));
+
+    // Create mock request
+    const request = new Request(
+      'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
+      { method: 'DELETE' }
+    );
+
+    // Execute DELETE
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: '1' }),
+    });
+    const data = await response.json();
+
+    // Assertions
+    expect(response.status).toBe(500);
+    expect(data.error).toContain('Failed to check attachment references');
+  });
+
+  test('Should return 404 when attachment not found', async () => {
+    // Mock: Attachment not found
+    supabase.from = jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'Not found' },
+        }),
+      })),
+    }));
+
+    // Create mock request
+    const request = new Request(
+      'http://localhost:3000/api/tasks/1/attachments?attachmentId=non-existent',
+      { method: 'DELETE' }
+    );
+
+    // Execute DELETE
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: '1' }),
+    });
+    const data = await response.json();
+
+    // Assertions
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Attachment not found');
+  });
+
+  test('Should return 400 when attachmentId is missing', async () => {
+    // Create mock request without attachmentId
+    const request = new Request(
+      'http://localhost:3000/api/tasks/1/attachments',
+      { method: 'DELETE' }
+    );
+
+    // Execute DELETE
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: '1' }),
+    });
+    const data = await response.json();
+
+    // Assertions
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Attachment ID is required');
+  });
+});

--- a/__tests__/unit/api/attachments-route.test.ts
+++ b/__tests__/unit/api/attachments-route.test.ts
@@ -5,6 +5,7 @@
  * when no other tasks reference the same storage_path
  */
 
+import { NextRequest } from 'next/server';
 import { DELETE } from '@/app/api/tasks/[id]/attachments/route';
 
 // Mock chain builder for Supabase
@@ -103,7 +104,7 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
     });
 
     // Create mock request
-    const request = new Request(
+    const request = new NextRequest(
       'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
       { method: 'DELETE' }
     );
@@ -173,7 +174,7 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
     }));
 
     // Create mock request
-    const request = new Request(
+    const request = new NextRequest(
       'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
       { method: 'DELETE' }
     );
@@ -232,7 +233,7 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
     }));
 
     // Create mock request
-    const request = new Request(
+    const request = new NextRequest(
       'http://localhost:3000/api/tasks/1/attachments?attachmentId=attachment-1',
       { method: 'DELETE' }
     );
@@ -261,7 +262,7 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
     }));
 
     // Create mock request
-    const request = new Request(
+    const request = new NextRequest(
       'http://localhost:3000/api/tasks/1/attachments?attachmentId=non-existent',
       { method: 'DELETE' }
     );
@@ -279,7 +280,7 @@ describe('DELETE /api/tasks/[id]/attachments - Reference Counting', () => {
 
   test('Should return 400 when attachmentId is missing', async () => {
     // Create mock request without attachmentId
-    const request = new Request(
+    const request = new NextRequest(
       'http://localhost:3000/api/tasks/1/attachments',
       { method: 'DELETE' }
     );

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -213,9 +213,10 @@ export async function DELETE(
     }
 
     // Check if other tasks reference the same storage_path (for recurring tasks)
-    const { data: referencingAttachments, error: refError } = await supabase
+    // Count BEFORE deletion to know total references
+    const { data: referencingAttachmentsBefore, error: refError } = await supabase
       .from('attachments')
-      .select('id')
+      .select('id, task_id')
       .eq('storage_path', attachment.storage_path);
 
     if (refError) {
@@ -223,25 +224,11 @@ export async function DELETE(
       return NextResponse.json({ error: 'Failed to check attachment references' }, { status: 500 });
     }
 
-    const referenceCount = referencingAttachments?.length || 0;
-    console.log(`🔍 Attachment ${attachmentId} has ${referenceCount} reference(s) in the database`);
+    const referenceCountBefore = referencingAttachmentsBefore?.length || 0;
+    console.log(`📊 BEFORE deletion: ${referenceCountBefore} attachment(s) reference storage_path: ${attachment.storage_path}`);
+    console.log(`📋 Task IDs with this attachment:`, referencingAttachmentsBefore?.map(a => a.task_id).join(', '));
 
-    // Only delete from storage if this is the last reference
-    if (referenceCount <= 1) {
-      console.log('🗑️  Last reference - deleting from storage bucket');
-      const { error: storageError } = await supabaseAdmin.storage
-        .from('attachments')
-        .remove([attachment.storage_path]);
-
-      if (storageError) {
-        console.error('Error deleting file from storage:', storageError);
-        // Continue anyway to delete from database
-      }
-    } else {
-      console.log(`⏭️  ${referenceCount - 1} other reference(s) exist - keeping file in storage bucket`);
-    }
-
-    // Always delete the database row for this task's attachment
+    // Delete the database row for this task's attachment FIRST
     const { error: dbError } = await supabase
       .from('attachments')
       .delete()
@@ -252,10 +239,50 @@ export async function DELETE(
       return NextResponse.json({ error: 'Failed to delete attachment' }, { status: 500 });
     }
 
+    console.log(`✅ Deleted attachment record for task ${taskId}`);
+
+    // Now check if any OTHER tasks still reference this storage_path
+    const { data: referencingAttachmentsAfter, error: refErrorAfter } = await supabase
+      .from('attachments')
+      .select('id, task_id')
+      .eq('storage_path', attachment.storage_path);
+
+    if (refErrorAfter) {
+      console.error('Error checking remaining attachment references:', refErrorAfter);
+      // Continue anyway - we already deleted from DB
+    }
+
+    const referenceCountAfter = referencingAttachmentsAfter?.length || 0;
+    console.log(`📊 AFTER deletion: ${referenceCountAfter} attachment(s) still reference this storage_path`);
+
+    if (referenceCountAfter > 0) {
+      console.log(`📋 Remaining task IDs:`, referencingAttachmentsAfter?.map(a => a.task_id).join(', '));
+    }
+
+    let deletedFromStorage = false;
+
+    // Only delete from storage if NO other references remain
+    if (referenceCountAfter === 0) {
+      console.log('🗑️  Last reference removed - deleting file from storage bucket');
+      const { error: storageError } = await supabaseAdmin.storage
+        .from('attachments')
+        .remove([attachment.storage_path]);
+
+      if (storageError) {
+        console.error('❌ Error deleting file from storage:', storageError);
+      } else {
+        console.log('✅ File deleted from storage bucket');
+        deletedFromStorage = true;
+      }
+    } else {
+      console.log(`⏭️  ${referenceCountAfter} other reference(s) still exist - keeping file in storage bucket`);
+    }
+
     return NextResponse.json({
       ok: true,
       message: 'Attachment deleted successfully',
-      deletedFromStorage: referenceCount <= 1
+      deletedFromStorage,
+      referencesRemaining: referenceCountAfter
     });
   } catch (error) {
     console.error('Error in DELETE /api/tasks/[id]/attachments:', error);

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -212,17 +212,36 @@ export async function DELETE(
       return NextResponse.json({ error: 'Attachment not found' }, { status: 404 });
     }
 
-    // Delete file from storage (use admin client)
-    const { error: storageError } = await supabaseAdmin.storage
+    // Check if other tasks reference the same storage_path (for recurring tasks)
+    const { data: referencingAttachments, error: refError } = await supabase
       .from('attachments')
-      .remove([attachment.storage_path]);
+      .select('id')
+      .eq('storage_path', attachment.storage_path);
 
-    if (storageError) {
-      console.error('Error deleting file from storage:', storageError);
-      // Continue anyway to delete from database
+    if (refError) {
+      console.error('Error checking attachment references:', refError);
+      return NextResponse.json({ error: 'Failed to check attachment references' }, { status: 500 });
     }
 
-    // Delete from database
+    const referenceCount = referencingAttachments?.length || 0;
+    console.log(`🔍 Attachment ${attachmentId} has ${referenceCount} reference(s) in the database`);
+
+    // Only delete from storage if this is the last reference
+    if (referenceCount <= 1) {
+      console.log('🗑️  Last reference - deleting from storage bucket');
+      const { error: storageError } = await supabaseAdmin.storage
+        .from('attachments')
+        .remove([attachment.storage_path]);
+
+      if (storageError) {
+        console.error('Error deleting file from storage:', storageError);
+        // Continue anyway to delete from database
+      }
+    } else {
+      console.log(`⏭️  ${referenceCount - 1} other reference(s) exist - keeping file in storage bucket`);
+    }
+
+    // Always delete the database row for this task's attachment
     const { error: dbError } = await supabase
       .from('attachments')
       .delete()
@@ -233,7 +252,11 @@ export async function DELETE(
       return NextResponse.json({ error: 'Failed to delete attachment' }, { status: 500 });
     }
 
-    return NextResponse.json({ ok: true, message: 'Attachment deleted successfully' });
+    return NextResponse.json({
+      ok: true,
+      message: 'Attachment deleted successfully',
+      deletedFromStorage: referenceCount <= 1
+    });
   } catch (error) {
     console.error('Error in DELETE /api/tasks/[id]/attachments:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
if task has a recurrence, should show this:
📊 BEFORE deletion: 2 attachment(s) reference storage_path: task-9/1762185293114-Leong_Rui_Tao_Q4_2025_All_Employee_Meeting_Virtual_Background.png
📋 Task IDs with this attachment: 9, 270
✅ Deleted attachment record for task 270
📊 AFTER deletion: 1 attachment(s) still reference this storage_path
📋 Remaining task IDs: 9
⏭️  1 other reference(s) still exist - keeping file in storage bucket 