### PR TITLE
fix: Correct Supabase import in attachments API route

### DIFF
--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/db';
+import { supabase } from '@/lib/supabaseClient';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { MAX_FILE_SIZE, SUPPORTED_MIME_TYPES, getFileExtension } from '@/types/attachment';
 


### PR DESCRIPTION
Changed import from '@/lib/db' to '@/lib/supabaseClient' to match test mocks and maintain consistency with the rest of the application.

This resolves 3 failing unit tests:
- Should delete from storage when attachment has only 1 reference
- Should NOT delete from storage when attachment has multiple references
- Should handle error when checking attachment references